### PR TITLE
build: use `@sanity/pkg-utils`

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  extract: {
+    rules: {
+      'ae-missing-release-tag': 'warn',
+      'tsdoc-undefined-tag': 'warn',
+    },
+  },
+  minify: false,
+})

--- a/package.json
+++ b/package.json
@@ -2,23 +2,31 @@
   "name": "@portabletext/types",
   "version": "1.0.3",
   "description": "Shared TypeScript definitions for core Portable Text data structures",
-  "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "type": "module",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "sideEffects": false,
   "engines": {
     "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
   },
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "scripts": {
     "docs": "typedoc",
     "test": "eslint . && npm run build && node test/test.js",
     "prepublishOnly": "npm run build && npm run test",
-    "build": "tsc --declaration"
+    "build": "pkg-utils build"
   },
   "repository": {
     "type": "git",
@@ -30,6 +38,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "devDependencies": {
+    "@sanity/pkg-utils": "^1.15.0",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
     "eslint": "^7.32.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "strict": true,
     "lib": ["ES2020"],
+    "rootDir": ".",
     "outDir": "dist",
-    "module": "ES2020"
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
   }
 }


### PR DESCRIPTION
Configures `@sanity/pkg-utils` to build `@portabletext/types`.