### PR TITLE
chore: remove support for node 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
           - 16
           - 14
-          - 12
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "sideEffects": false,
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This removes Node 12 from the `"engines"` list in `package.json`, and from the GitHub `test` action.